### PR TITLE
Fix: vue-skip-to label

### DIFF
--- a/src/.vuepress/theme/layouts/GlobalLayout.vue
+++ b/src/.vuepress/theme/layouts/GlobalLayout.vue
@@ -21,7 +21,7 @@
       <VueSkipTo
         v-if="$themeLocaleConfig.skipTo"
         :to="$themeLocaleConfig.skipTo.to"
-        :list-label="$themeLocaleConfig.skipTo.label"
+        :label="$themeLocaleConfig.skipTo.label"
         class="z-20"
       />
     </ClientOnly>
@@ -50,6 +50,7 @@ export default {
   },
 
   setup (_, { root, refs }) {
+    console.log(root.$themeLocaleConfig.skipTo)
     const colorModeConfig = ref(root.$themeConfig.colorMode)
 
     const layout = computed(() => {

--- a/src/.vuepress/theme/layouts/GlobalLayout.vue
+++ b/src/.vuepress/theme/layouts/GlobalLayout.vue
@@ -50,7 +50,6 @@ export default {
   },
 
   setup (_, { root, refs }) {
-    console.log(root.$themeLocaleConfig.skipTo)
     const colorModeConfig = ref(root.$themeConfig.colorMode)
 
     const layout = computed(() => {


### PR DESCRIPTION
I fixed only English labels were being applied.

`:list-label` => `:label`

## jp version
<img width="424" alt="Screen Shot 2021-01-24 at 8 56 45" src="https://user-images.githubusercontent.com/1996642/105617787-72a23a00-5e24-11eb-891c-386f787c2d0d.png">

## pt version
<img width="356" alt="Screen Shot 2021-01-24 at 8 57 05" src="https://user-images.githubusercontent.com/1996642/105617789-73d36700-5e24-11eb-9d77-cd7864838004.png">
