### PR TITLE
Update: jp sidebar contribute locales

### DIFF
--- a/src/.vuepress/config/languages/jp/sidebarStructure.js
+++ b/src/.vuepress/config/languages/jp/sidebarStructure.js
@@ -6,7 +6,7 @@ module.exports = {
         '',
         ['ロードマップ', 'https://github.com/vue-a11y/vue-a11y.com/projects/2'],
         ['参加者', 'people'],
-        ['コントリビュート', 'how-to-contribute'],
+        ['貢献する方法', 'how-to-contribute'],
       ]
     },
     {


### PR DESCRIPTION
I forgot sidebar "how-to-contribute" translation. 🙇

<img width="971" alt="Screen Shot 2021-01-24 at 11 34 54" src="https://user-images.githubusercontent.com/1996642/105619659-47294a80-5e38-11eb-93a8-337b808ba682.png">

For the sake of consistency, page title is now correct.

<img width="990" alt="Screen Shot 2021-01-24 at 11 39 03" src="https://user-images.githubusercontent.com/1996642/105619716-c7e84680-5e38-11eb-996c-2dc0fea527c3.png">
