### PR TITLE
chore: update EN project sidebar links

### DIFF
--- a/src/.vuepress/config/languages/en/sidebarStructure.js
+++ b/src/.vuepress/config/languages/en/sidebarStructure.js
@@ -12,10 +12,9 @@ module.exports = {
     {
       title: 'Accessibility',
       children: [
-        ['Basics', 'https://v3.vuejs.org/guide/a11y-basics.html'],
-        ['Semantics', 'https://v3.vuejs.org/guide/a11y-semantics.html'],
-        ['Standards', 'https://v3.vuejs.org/guide/a11y-standards.html'],
-        ['Resources', 'https://v3.vuejs.org/guide/a11y-resources.html'],
+        ['Vue.js Docs', 'https://vuejs.org/guide/best-practices/accessibility.html'],
+        ['Standards', 'https://vuejs.org/guide/best-practices/accessibility.html#standards'],
+        ['Resources', 'https://vuejs.org/guide/best-practices/accessibility.html#resources'],
         ['Awesome', 'https://github.com/vue-a11y/awesome-a11y-vue']
       ]
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10849207/195432156-dc2c31fd-6e8e-4990-a342-376f454f8b4c.png)

The sidebar on the Project page currently has 5 links (seen above). Clicking any of the first 4 links will redirect you to this Vue.js Docs page:

https://vuejs.org/guide/best-practices/accessibility.html

This PR changes the links slightly so users don't get redirected and land on a (part of the) page that is relevant to the link text.

For translations, `jp` and `pt` are the only two besides `en` that have a `sidebarStructure.js` file. The links in those translations also still have meaningful content behind them.

For `jp` specifically, there is [a new version of the docs](https://ja.vuejs.org/guide/best-practices/accessibility.html), but I'm not confident in changing the `jp` links without understanding the language. For example, maybe the new version of the `jp` Vue.js docs is of a lower quality. Probably better if this was solved by a language native.
