### PR TITLE
chore: update JP project sidebar links

### DIFF
--- a/src/.vuepress/config/languages/jp/sidebarStructure.js
+++ b/src/.vuepress/config/languages/jp/sidebarStructure.js
@@ -12,10 +12,9 @@ module.exports = {
     {
       title: 'アクセシビリティ',
       children: [
-        ['基礎', 'https://v3.ja.vuejs.org/guide/a11y-basics.html'],
-        ['セマンティクス', 'https://v3.ja.vuejs.org/guide/a11y-semantics.html'],
-        ['標準', 'https://v3.ja.vuejs.org/guide/a11y-standards.html'],
-        ['リソース', 'https://v3.ja.vuejs.org/guide/a11y-resources.html'],
+        ['Vue.js ドキュメント', 'https://ja.vuejs.org/guide/best-practices/accessibility.html'],
+        ['標準規格', 'https://ja.vuejs.org/guide/best-practices/accessibility.html#%E6%A8%99%E6%BA%96%E8%A6%8F%E6%A0%BC'],
+        ['リソース', 'https://ja.vuejs.org/guide/best-practices/accessibility.html#%E3%83%AA%E3%82%BD%E3%83%BC%E3%82%B9'],
         ['Awesome', 'https://github.com/vue-a11y/awesome-a11y-vue']
       ]
     }


### PR DESCRIPTION
Update Sidebar JP 

<table>
<tr>
	<td>Before
	<td>After
<tr>
	<td><img width="221" alt="Screen Shot: Before JP project sidebar" src="https://user-images.githubusercontent.com/1996642/196647636-79922c59-b8e9-4e0e-ae4b-92dfe8255352.png">
	<td><img width="231" alt="Screen Shot: After JP project sidebar" src="https://user-images.githubusercontent.com/1996642/196647853-63238b9b-d784-4b66-8f5e-f24a9c3177a2.png">
</table>

ref: https://github.com/vue-a11y/vue-a11y.com/pull/77